### PR TITLE
Open Photo gallery instead of document viewer

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -270,8 +270,8 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         croppedUri = null;
         if (this.mediaType == PICTURE) {
             intent.setType("image/*");
+            intent.setAction(Intent.ACTION_PICK);
             if (this.allowEdit) {
-                intent.setAction(Intent.ACTION_PICK);
                 intent.putExtra("crop", "true");
                 if (targetWidth > 0) {
                     intent.putExtra("outputX", targetWidth);
@@ -286,9 +286,6 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 File photo = createCaptureFile(encodingType);
                 croppedUri = Uri.fromFile(photo);
                 intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, croppedUri);
-            } else {
-                intent.setAction(Intent.ACTION_GET_CONTENT);
-                intent.addCategory(Intent.CATEGORY_OPENABLE);
             }
         } else if (this.mediaType == VIDEO) {
                 intent.setType("video/*");


### PR DESCRIPTION
In android, if allowEdit is equal to false while choosing from gallery, the document viewer would open instead of the photo gallery.
The change is that ACTION_PICK is used wether or not allowEdit is enabled.
